### PR TITLE
Wrap all fn's with `Promise.method`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,9 @@ node_js:
 
 after_script:
   - npm run cover; cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+
+deploy:
+  provider: npm
+    api_key: "$NPM_API_TOKEN"
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language:
+  - node_js
+
+node_js:
+  - "stable"
+  - "4.2"
+  - "4.1"
+  - "4.0"
+  - "0.12"
+  - "0.11"
+  - "iojs"
+
+after_script:
+  - npm run cover; cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<a name="module_retryify"></a>
-## retryify
+# retryify [![Build Status](https://travis-ci.org/smartcar/retryify.svg?branch=master)](https://travis-ci.org/smartcar/retryify) [![Coverage Status](https://coveralls.io/repos/smartcar/retryify/badge.svg?branch=master&service=github)](https://coveralls.io/github/smartcar/retryify?branch=master)
+
 Quickly and easily wrap functions to make them retry when they fail. Uses
 bluebird promises for maximum convenience!
 
@@ -7,7 +7,7 @@ bluebird promises for maximum convenience!
 
     $ npm install retryify
 
-**Example**  
+**Example**
 ```js
 // create a new retryify wrapper with some options set.
 var retryify = require('retryify')({
@@ -53,9 +53,9 @@ get('http://google.com')
 Retry module setup function. Takes an options object that configures the
 default retry options.
 
-**Kind**: inner method of <code>[retryify](#module_retryify)</code>  
+**Kind**: inner method of <code>[retryify](#module_retryify)</code>
 **Returns**: <code>function</code> - [retryWrapper](retryWrapper) A decorator function that wraps a
-  a function to turn it into a retry-enabled function.  
+  a function to turn it into a retry-enabled function.
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -71,8 +71,8 @@ default retry options.
 retryify function decorator. Allows configuration on a function by function
 basis.
 
-**Kind**: inner method of <code>[retryify](#module_retryify..retryify)</code>  
-**Returns**: <code>function</code> - The wrapped function.  
+**Kind**: inner method of <code>[retryify](#module_retryify..retryify)</code>
+**Returns**: <code>function</code> - The wrapped function.
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# retryify [![Build Status](https://travis-ci.org/smartcar/retryify.svg?branch=master)](https://travis-ci.org/smartcar/retryify) [![Coverage Status](https://coveralls.io/repos/smartcar/retryify/badge.svg?branch=master&service=github)](https://coveralls.io/github/smartcar/retryify?branch=master)
+# retryify [![NPM version](https://img.shields.io/npm/v/retryify.svg)](https://www.npmjs.com/package/retryify) [![Build Status](https://travis-ci.org/smartcar/retryify.svg?branch=master)](https://travis-ci.org/smartcar/retryify) [![Coverage Status](https://coveralls.io/repos/smartcar/retryify/badge.svg?branch=master&service=github)](https://coveralls.io/github/smartcar/retryify?branch=master)
 
 Quickly and easily wrap functions to make them retry when they fail. Uses
 bluebird promises for maximum convenience!

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ var onError = function(context, err) {
   context.attempts += 1;
 
   var logMessage = format('retrying function %s in %s ms : attempts: %s',
-                          context.fn.name ? context.fn.name : '<Anonymous>',
+                          context.fnName ? context.fnName : '<Anonymous>',
                           delay,
                           context.attempts);
 
@@ -221,7 +221,8 @@ var retryify = function(options) {
       }
 
       var context = {
-        fn: fn,
+        fn: Promise.method(fn),
+        fnName: fn.name,
         args: args,
         // Make sure `this` is preserved when executing the wrapped function
         fnThis: getOpt(this, null),

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "bluebird": "^2.9.27"
   },
   "devDependencies": {
+    "coveralls": "^2.11.4",
     "istanbul": "^0.3.15",
     "jsdoc-to-markdown": "^1.1.1",
     "mocha": "^2.2.5"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "retryify",
-  "version": "1.0.4",
-  "author": "Philip Hayes <philip.hayes@smartcar.com>",
+  "version": "1.0.5",
+  "author": "Smartcar <hello@smartcar.com>",
   "description": "Wrap a function to retry on specific errors",
   "license": "MIT",
   "repository": "smartcar/retryify",
@@ -18,7 +18,8 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "NODE_ENV=development istanbul cover _mocha -- --ui=tdd --recursive --timeout=10000",
+    "test": "mocha --ui=tdd --recursive",
+    "cover": "istanbul cover _mocha -- --ui=tdd --recursive",
     "readme": "jsdoc2md index.js > README.md"
   },
   "dependencies": {

--- a/test/test_retry.js
+++ b/test/test_retry.js
@@ -21,6 +21,16 @@ suite('Retryify', function() {
     retryLib();
   });
 
+  test('no times, standard fn', function() {
+    var addABC = retryify(function(a, b, c) {
+      return a + b + c;
+    }, { retries: 0 });
+
+    return addABC(1, 2, 3).then(function(sum) {
+      assert.equal(sum, 6);
+    });
+  });
+
   test('no times, promise fn', function() {
     var addABC = retryify(function(a, b, c) {
       return Promise.delay(5).then(function() {
@@ -29,6 +39,23 @@ suite('Retryify', function() {
     }, { retries: 0 });
 
     return addABC(1, 2, 3).then(function(sum) {
+      assert.equal(sum, 6);
+    });
+  });
+
+  test('once, error on first call, standard fn', function() {
+    var retries = 1;
+
+    var addFail = retryify(function(a, b, c) {
+      if (retries > 0) {
+        retries -= 1;
+        throw new Error('Oh no! The promise failed :0');
+      } else {
+        return a + b + c;
+      }
+    }, { retries: retries });
+
+    return addFail(1, 2, 3).then(function(sum) {
       assert.equal(sum, 6);
     });
   });


### PR DESCRIPTION
This allows standard synchronous functions to work transparently with retryify.
