### PR TITLE
Check the argument type that is passed into the main export

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,10 +171,19 @@ retryRec = function(context) {
  * @param {Function} [options.log] Logging function that takes a message as
  *   its first parameter.
  *
+ * @throws TypeError when function is passed instead of options object. This
+ * guards against the common mistake of assuming the default export is the
+ * retryifyer
+ *
  * @return {Function} {@link retryWrapper} A decorator function that wraps a
  *   a function to turn it into a retry-enabled function.
  */
 var retryify = function(options) {
+
+  if (typeof options === 'function') {
+    throw new TypeError('options object expected but was passed a function');
+  }
+
   var _options = options || {};
   _options.retries = getOpt(_options.retries, 3);
   _options.timeout = getOpt(_options.timeout, 300);

--- a/index.js
+++ b/index.js
@@ -171,9 +171,10 @@ retryRec = function(context) {
  * @param {Function} [options.log] Logging function that takes a message as
  *   its first parameter.
  *
- * @throws TypeError when function is passed instead of options object. This
- * guards against the common mistake of assuming the default export is the
- * retryifyer
+ * @throws TypeError when function is passed instead of options object.
+ * To use retryify it first must be "constructed" by passing in an options
+ * object and the returned function is what is supposed to take the function
+ * to retry.
  *
  * @return {Function} {@link retryWrapper} A decorator function that wraps a
  *   a function to turn it into a retry-enabled function.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "retryify",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Wrap a function to retry on specific errors",
   "main": "index.js",
   "license": "MIT",
@@ -38,7 +38,7 @@
     "posttest": "npm run lint -s",
     "lint": "eslint . --cache",
     "cover": "nyc npm test -s",
-    "readme": "jsdoc2md index.js > README.md"
+    "readme": "jsdoc2md index.js | sed 's/[\t ]*$//g' > readme.md"
   },
   "dependencies": {
     "bluebird": "^3.4.6"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "posttest": "npm run lint -s",
     "lint": "eslint . --cache",
     "cover": "nyc npm test -s",
-    "readme": "jsdoc2md index.js | sed 's/[\t ]*$//g' > readme.md"
+    "readme": "jsdoc2md --example-lang js --template readme.hbs index.js | sed 's/[\t ]*$//g' > readme.md"
   },
   "dependencies": {
     "bluebird": "^3.4.6"

--- a/readme.hbs
+++ b/readme.hbs
@@ -1,0 +1,17 @@
+# retryify [![NPM version][npm-image]][npm-url] [![Build Status][ci-image]][ci-url] [![Coverage Status][coverage-image]][coverage-url]
+
+{{#orphans ~}}
+{{>body}}
+{{>member-index~}}
+{{>separator~}}
+{{>members~}}
+{{/orphans~}}
+
+[npm-url]: https://www.npmjs.com/package/retryify
+[npm-image]: https://img.shields.io/npm/v/retryify.svg?style=flat-square
+
+[ci-url]: https://travis-ci.org/smartcar/retryify
+[ci-image]: https://img.shields.io/travis/smartcar/retryify/master.svg?style=flat-square
+
+[coverage-url]: https://codecov.io/gh/smartcar/retryify
+[coverage-image]: https://img.shields.io/codecov/c/github/smartcar/retryify/master.svg?style=flat-square

--- a/readme.md
+++ b/readme.md
@@ -59,9 +59,10 @@ default retry options.
   a function to turn it into a retry-enabled function.
 **Throws**:
 
-- TypeError when function is passed instead of options object. This
-guards against the common mistake of assuming the default export is the
-retryifyer
+- TypeError when function is passed instead of options object.
+To use retryify it first must be "constructed" by passing in an options
+object and the returned function is what is supposed to take the function
+to retry.
 
 
 | Param | Type | Default | Description |

--- a/readme.md
+++ b/readme.md
@@ -45,10 +45,11 @@ get('http://google.com')
 ```
 
 * [retryify](#module_retryify)
-  * [~retryify([options])](#module_retryify..retryify) ⇒ <code>function</code>
-    * [~retryWrapper([innerOptions], fn)](#module_retryify..retryify..retryWrapper) ⇒ <code>function</code>
+    * [~retryify([options])](#module_retryify..retryify) ⇒ <code>function</code>
+        * [~retryWrapper([innerOptions], fn)](#module_retryify..retryify..retryWrapper) ⇒ <code>function</code>
 
 <a name="module_retryify..retryify"></a>
+
 ### retryify~retryify([options]) ⇒ <code>function</code>
 Retry module setup function. Takes an options object that configures the
 default retry options.
@@ -56,6 +57,12 @@ default retry options.
 **Kind**: inner method of <code>[retryify](#module_retryify)</code>
 **Returns**: <code>function</code> - [retryWrapper](retryWrapper) A decorator function that wraps a
   a function to turn it into a retry-enabled function.
+**Throws**:
+
+- TypeError when function is passed instead of options object. This
+guards against the common mistake of assuming the default export is the
+retryifyer
+
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -67,6 +74,7 @@ default retry options.
 | [options.log] | <code>function</code> |  | Logging function that takes a message as   its first parameter. |
 
 <a name="module_retryify..retryify..retryWrapper"></a>
+
 #### retryify~retryWrapper([innerOptions], fn) ⇒ <code>function</code>
 retryify function decorator. Allows configuration on a function by function
 basis.

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,8 +1,7 @@
-// Lint settings to support 'import' and 'export' for AVA tests
+// Lint settings to support 'async' and 'await' for AVA tests
 
 module.exports = {
   parserOptions: {
     ecmaVersion: 2017,
-    sourceType: 'module',
   },
 };

--- a/test/test_retry.js
+++ b/test/test_retry.js
@@ -1,7 +1,9 @@
-import test from 'ava';
-import util from 'util';
-import Promise from 'bluebird';
-import retryLib from '../index';
+'use strict';
+
+const test = require('ava');
+const util = require('util');
+const Promise = require('bluebird');
+const retryLib = require('../index');
 
 const retryify = retryLib({
   retries: 2,
@@ -11,6 +13,13 @@ const retryify = retryLib({
 
 // MUST GET 100% COVERAGE (ノ._.)ノ
 retryLib();
+
+test('function passed to setup function', function(t) {
+
+  const err = t.throws(() => retryLib(() => 1), TypeError);
+  t.is(err.message, 'options object expected but was passed a function');
+
+});
 
 test('no times, standard fn', async function(t) {
   const addABC = retryify(function(a, b, c) {


### PR DESCRIPTION
To use `retryify` it first must be "constructed" by passing in an options object and the returned function is what is supposed to take the function to retry. 

A common mistake is passing the function to retry directly to the "constructor".  Currently this leads to a silent failure, this PR modifies the code to throw a `TypeError` if this case occuers

Also created a readme template for `jsdoc2md` to use so that the autogenerated readme is output in the same format as the current readme