### PR TITLE
feat: initialDelay before retry execution

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,9 +61,9 @@ object and the returned function is what is supposed to take the function
 to retry.
 
 
-| Param | Type | Description |
-| --- | --- | --- |
-| [options] | [<code>Options</code>](#Options) | Optional configuration object |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | [<code>Options</code>](#Options) | <code>{}</code> | Optional configuration object |
 
 <a name="retryify..retryWrapper"></a>
 
@@ -88,9 +88,10 @@ basis.
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | [options.retries] | <code>Number</code> | <code>3</code> | Number of times to retry a wrapped   function |
-| [options.timeout] | <code>Number</code> | <code>300</code> | Amount of time to wait between retries |
+| [options.initialDelay] | <code>Number</code> | <code>0</code> | Amount of time (ms) to wait before any function attempts |
+| [options.timeout] | <code>Number</code> | <code>300</code> | Amount of time (ms) to wait between retries |
 | [options.factor] | <code>Number</code> | <code>2</code> | The exponential factor to scale the   timeout by every retry iteration. For example: with a factor of 2 and a   timeout of 100 ms, the first retry will fire after 100 ms, the second   after 200 ms, the third after 400 ms, etc.... The formula used to   calculate the delay between each retry:   ```timeout * Math.pow(factor, attempts)``` |
-| [options.errors] | <code>Error</code> \| <code>Array.&lt;Error&gt;</code> | <code>Error</code> | A single Error or an   array Errors that trigger a retry when caught |
+| [options.shouldRetry] | <code>function</code> | <code>() &#x3D;&gt; true</code> | Invoked with the thrown error, retryify will retry if this method returns true. |
 | [options.log] | <code>function</code> |  | Logging function that takes a message as |
 
 


### PR DESCRIPTION
## Changes
This PR is for adding an `initialDelay` option (open to suggestions for names). This is the amount of time in milliseconds to wait before any function attempts.

## Test
The added test calls a retry-wrapped function with 1500 ms initial delay and 0 retries. The function flips a boolean flag after the delay. The test verifies the state of the flag before and after the delay.

## "Fix" to other tests
I'm not sure if this was intentional, but all the tests had the parameters flip-flopped. It looks like the tester was attempting to override the default options, but instead passed the function first, thus using only defaults.

Retry wrapped function signature is `(<options>, <function>)`. The tests were passing because the default options caught all the test cases.